### PR TITLE
feat: exposing container ports

### DIFF
--- a/examples/nodejs-project-example.ts
+++ b/examples/nodejs-project-example.ts
@@ -21,7 +21,7 @@ async function main() {
 2. A package.json with necessary dependencies
 3. A README.md with setup instructions
 4. A simple route that returns "Hello World"
-5. Include a console log message "Listening on port 3000"
+5. Include a console log message "Listening on port 1234"
 
 Please format your response as follows:
 FILE: filename
@@ -83,6 +83,7 @@ Separate each file with a blank line.`
         cwd: '/project'
       },
       dependencies: ['express'],
+      ports: [1234],
       streamOutput: {
         dependencyStdout: (data) => {
           console.log('Dependency stdout:', data);

--- a/src/code-execution-tool.ts
+++ b/src/code-execution-tool.ts
@@ -44,6 +44,7 @@ export function createCodeExecutionTool(config: CodeExecutionToolConfig = {}) {
       entryFile: z.string().describe('Path to the entry file relative to the mounted directory'),
       cwd: z.string().describe('Working directory path that should be mounted')
     }).optional().describe('Optional configuration for running an entire application'),
+    ports: z.array(z.number()).optional().describe('Ports to expose from the container to the host'),
     streamOutput: z.object({
       stdout: z.function().args(z.string()).optional(),
       stderr: z.function().args(z.string()).optional(),
@@ -67,6 +68,7 @@ export function createCodeExecutionTool(config: CodeExecutionToolConfig = {}) {
   //    sessionId,
       environment = {},
       runApp,
+      ports,
       streamOutput
     }: z.infer<typeof codeExecutionSchema>): Promise<CodeExecutionResult> => {
       const strategy = config.defaultStrategy ?? 'per_execution';
@@ -77,7 +79,8 @@ export function createCodeExecutionTool(config: CodeExecutionToolConfig = {}) {
         containerConfig: {
           image: getImageForLanguage(language),
           environment,
-          mounts: config.mounts
+          mounts: config.mounts,
+          ports
         }
       });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface ContainerConfig {
   mounts?: MountOptions[];
   environment?: Record<string, string>;
   name?: string;
+  ports?: number[]; // Host ports to publish (TCP)
 }
 
 export interface ExecutionResult {


### PR DESCRIPTION
We're on Docker at the moment - so exposing the ports went relatively easy :) It works nice with the `nodejs-project-example` where the server is generated and exposed on the 1234 port